### PR TITLE
Fix null field in DeliMod constructor

### DIFF
--- a/Deli/src/Deli.cs
+++ b/Deli/src/Deli.cs
@@ -313,7 +313,7 @@ namespace Deli
             }
 
             // Add the Mod to the kernel.
-            Services.Get<IDictionary<string, Mod>>().Unwrap().Add(mod.Info.Guid, mod);
+            Services.Get<IDictionary<string, Mod>>().Expect("Could not find mod GUID dictionary.").Add(mod.Info.Guid, mod);
         }
     }
 }

--- a/Deli/src/Deli.cs
+++ b/Deli/src/Deli.cs
@@ -21,16 +21,16 @@ namespace Deli
     [BepInPlugin(Constants.Guid, Constants.Name, Constants.Version)]
     public class Deli : BaseUnityPlugin
     {
-        private StandardServiceKernel _kernel;
+        private static StandardServiceKernel _kernel;
+
+        private static IServiceKernel Kernel => _kernel ?? (_kernel = new StandardServiceKernel());
+        public static IServiceResolver Services => Kernel;
 
         private ConfigEntry<bool> WaitForDebugger;
-
-        public IServiceResolver Services => _kernel;
 
         private void Awake()
         {
             Logger.LogInfo($"Deli is Awake! Version {Constants.Version} ({Constants.GitBranch}-{Constants.GitDescribe})");
-            _kernel = new StandardServiceKernel();
             Bind();
             RegisterConfig();
             if (WaitForDebugger.Value) StartCoroutine(WaitForKeypress());
@@ -47,64 +47,67 @@ namespace Deli
         private void Bind()
         {
             // Cleanup
-            _kernel.Bind<IList<IDisposable>>().ToConstant(new List<IDisposable>());
+            Kernel.Bind<IList<IDisposable>>().ToConstant(new List<IDisposable>());
 
             // Simple constants
-            _kernel.Bind<Deli>().ToConstant(this);
-            _kernel.Bind<ManualLogSource>().ToConstant(Logger);
+            Kernel.Bind<Deli>().ToConstant(this);
+            Kernel.Bind<ManualLogSource>().ToConstant(Logger);
             {
                 var manager = new GameObject("Deli Manager");
                 DontDestroyOnLoad(manager);
 
-                _kernel.Bind<GameObject>().ToConstant(manager);
+                Kernel.Bind<GameObject>().ToConstant(manager);
             }
 
             // JSON
-            _kernel.Bind<NamingStrategy>().ToConstant(new CamelCaseNamingStrategy());
-            _kernel.Bind<IContractResolver>().ToRecursiveNopMethod(x => new DefaultContractResolver
+            Kernel.Bind<NamingStrategy>().ToConstant(new CamelCaseNamingStrategy());
+            Kernel.Bind<IContractResolver>().ToRecursiveNopMethod(x => new DefaultContractResolver
             {
                 NamingStrategy = x.Get<NamingStrategy>().Expect("JSON naming strategy not found")
             }).InSingletonNopScope();
-            _kernel.Bind<IList<JsonConverter>>().ToConstant(new List<JsonConverter>
+            Kernel.Bind<IList<JsonConverter>>().ToConstant(new List<JsonConverter>
             {
                 new OptionJsonConverter()
             });
-            _kernel.Bind<JsonSerializerSettings>().ToRecursiveNopMethod(x => new JsonSerializerSettings
+            Kernel.Bind<JsonSerializerSettings>().ToRecursiveNopMethod(x => new JsonSerializerSettings
             {
                 ContractResolver = x.Get<IContractResolver>().Expect("JSON contract resolver not found"),
                 Converters = x.Get<IList<JsonConverter>>().Expect("JSON converters not found")
             }).InSingletonNopScope();
-            _kernel.Bind<JsonSerializer>().ToRecursiveNopMethod(x =>
+            Kernel.Bind<JsonSerializer>().ToRecursiveNopMethod(x =>
             {
                 var settings = x.Get<JsonSerializerSettings>().Expect("JSON settings not found.");
 
                 return JsonSerializer.Create(settings);
             }).InSingletonNopScope();
-            _kernel.BindJson<Mod.Manifest>();
+            Kernel.BindJson<Mod.Manifest>();
 
             // Basic impls
-            _kernel.Bind<IAssetReader<Assembly>>().ToConstant(new AssemblyAssetReader());
-            _kernel.Bind<IAssetReader<Option<JObject>>>().ToRecursiveNopMethod(x => new JObjectAssetReader(x)).InSingletonNopScope();
-            _kernel.Bind<IAssetReader<byte[]>>().ToConstant(new ByteArrayAssetReader());
+            Kernel.Bind<IAssetReader<Assembly>>().ToConstant(new AssemblyAssetReader());
+            Kernel.Bind<IAssetReader<Option<JObject>>>().ToRecursiveNopMethod(x => new JObjectAssetReader(x)).InSingletonNopScope();
+            Kernel.Bind<IAssetReader<byte[]>>().ToConstant(new ByteArrayAssetReader());
 
             // Associative services dictionaries
-            _kernel.Bind<IDictionary<string, IAssetLoader>>().ToConstant(new Dictionary<string, IAssetLoader>
+            Kernel.Bind<IDictionary<string, IAssetLoader>>().ToConstant(new Dictionary<string, IAssetLoader>
             {
                 ["assembly"] = new AssemblyAssetLoader()
             });
-            _kernel.Bind<IDictionary<string, Mod>>().ToConstant(new Dictionary<string, Mod>());
+            Kernel.Bind<IDictionary<string, Mod>>().ToConstant(new Dictionary<string, Mod>());
+            Kernel.Bind<IDictionary<Type, Mod>>().ToConstant(new Dictionary<Type, Mod>());
 
             // Enumerables
-            _kernel.Bind<IEnumerable<IAssetLoader>>().ToRecursiveMethod(x => x.Get<IDictionary<string, IAssetLoader>>().Map(v => (IEnumerable<IAssetLoader>) v.Values)).InTransientScope();
-            _kernel.Bind<IEnumerable<Mod>>().ToRecursiveMethod(x => x.Get<IDictionary<string, Mod>>().Map(v => (IEnumerable<Mod>) v.Values)).InTransientScope();
+            Kernel.Bind<IEnumerable<IAssetLoader>>().ToRecursiveMethod(x => x.Get<IDictionary<string, IAssetLoader>>().Map(v => (IEnumerable<IAssetLoader>) v.Values)).InTransientScope();
+            Kernel.Bind<IEnumerable<Mod>>().ToRecursiveMethod(x => x.Get<IDictionary<string, Mod>>().Map(v => (IEnumerable<Mod>) v.Values)).InTransientScope();
 
             // Contextual to dictionaries
-            _kernel.Bind<IAssetLoader, string>().ToWholeMethod((services, context) => services.Get<IDictionary<string, IAssetLoader>>().Map(x => x.OptionGetValue(context)).Flatten()).InTransientScope();
-            _kernel.Bind<Mod, string>().ToWholeMethod((services, context) => services.Get<IDictionary<string, Mod>>().Map(x => x.OptionGetValue(context)).Flatten()).InTransientScope();
+            Kernel.Bind<IAssetLoader, string>().ToWholeMethod((services, context) => services.Get<IDictionary<string, IAssetLoader>>().Map(x => x.OptionGetValue(context)).Flatten()).InTransientScope();
+            Kernel.Bind<Mod, string>().ToWholeMethod((services, context) => services.Get<IDictionary<string, Mod>>().Map(x => x.OptionGetValue(context)).Flatten()).InTransientScope();
+            Kernel.Bind<Mod, Type>().ToWholeMethod((services, context) => services.Get<IDictionary<Type, Mod>>().Map(x => x.OptionGetValue(context)).Flatten()).InTransientScope();
+            Kernel.Bind<Mod, DeliMod>().ToWholeMethod((services, context) => services.Get<Mod, Type>(context.GetType())).InTransientScope();
 
             // Custom impls
-            _kernel.Bind<ManualLogSource, string>().ToContextualNopMethod(x => BepInEx.Logging.Logger.CreateLogSource(x)).InSingletonScope();
-            _kernel.Bind<ConfigFile, string>().ToContextualNopMethod(x => new ConfigFile(Path.Combine(Constants.ConfigDirectory, $"{x}.cfg"), false)).InSingletonScope();
+            Kernel.Bind<ManualLogSource, string>().ToContextualNopMethod(x => BepInEx.Logging.Logger.CreateLogSource(x)).InSingletonScope();
+            Kernel.Bind<ConfigFile, string>().ToContextualNopMethod(x => new ConfigFile(Path.Combine(Constants.ConfigDirectory, $"{x}.cfg"), false)).InSingletonScope();
         }
 
         private void RegisterConfig()
@@ -212,7 +215,7 @@ namespace Deli
                     continue;
                 }
 
-                var disposables = _kernel.Get<IList<IDisposable>>().Unwrap();
+                var disposables = Kernel.Get<IList<IDisposable>>().Unwrap();
                 disposables.Add(zip);
                 disposables.Add(raw);
 

--- a/Deli/src/Entities/AssetLoaders/AssemblyAssetLoader.cs
+++ b/Deli/src/Entities/AssetLoaders/AssemblyAssetLoader.cs
@@ -148,6 +148,8 @@ namespace Deli
             if (!type.IsSubclassOf(typeof(DeliMod))) return false;
             
             var manager = services.Get<GameObject>().Expect("Could not find manager object.");
+            services.Get<IDictionary<Type, Mod>>().Expect("Could not find mod type dictionary.").Add(type, mod);
+
             manager.AddComponent(type);
 
             return true;

--- a/Deli/src/Entities/AssetLoaders/AssemblyAssetLoader.cs
+++ b/Deli/src/Entities/AssetLoaders/AssemblyAssetLoader.cs
@@ -146,17 +146,9 @@ namespace Deli
         private bool CheckIsDeliMod(IServiceResolver services, Mod mod, Type type)
         {
             if (!type.IsSubclassOf(typeof(DeliMod))) return false;
+            
             var manager = services.Get<GameObject>().Expect("Could not find manager object.");
-            manager.SetActive(false);
-            try
-            {
-                var modClass = (DeliMod) manager.AddComponent(type);
-                modClass.BaseMod = mod;
-            }
-            finally
-            {
-                manager.SetActive(true);
-            }
+            manager.AddComponent(type);
 
             return true;
         }

--- a/Deli/src/Entities/Mods/DeliMod.cs
+++ b/Deli/src/Entities/Mods/DeliMod.cs
@@ -2,10 +2,10 @@
 
 namespace Deli
 {
-	/// <summary>
-	///     Base class for plugin mods
-	/// </summary>
-	public abstract class DeliMod : MonoBehaviour
+    /// <summary>
+    ///     Base class for plugin mods
+    /// </summary>
+    public abstract class DeliMod : MonoBehaviour
     {
         public Mod BaseMod;
 

--- a/Deli/src/Entities/Mods/DeliMod.cs
+++ b/Deli/src/Entities/Mods/DeliMod.cs
@@ -2,11 +2,16 @@
 
 namespace Deli
 {
-    /// <summary>
-    ///     Base class for plugin mods
-    /// </summary>
-    public abstract class DeliMod : MonoBehaviour
+	/// <summary>
+	///     Base class for plugin mods
+	/// </summary>
+	public abstract class DeliMod : MonoBehaviour
     {
         public Mod BaseMod;
+
+        protected DeliMod()
+        {
+            BaseMod = Deli.Services.Get<Mod, DeliMod>(this).Expect("Could not acquire mod handle for " + GetType());
+        }
     }
 }


### PR DESCRIPTION
Fixes the `DeliMod.BaseMod` field being `null` in the constructor. This was problematic for H3MP.

Changes:
- Moves the kernel into static space
- Adds services that relate `Type`s to `Mod`s
- Adds protected constructor to `DeliMod` that accesses the services

Now that the field isn't being set outside the constructor, it really ought to be changed to a get-only property. I didn't do that because it would break mods built for v0.1.0.
