### PR TITLE
Add native assembly asset loader

### DIFF
--- a/Deli.Core/src/AssetLoaders/NativeAssembly.cs
+++ b/Deli.Core/src/AssetLoaders/NativeAssembly.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using ADepIn;
+
+namespace Deli.Core
+{
+	[QuickNamedBind("assembly.native")]
+	public class NativeAssemblyAssetLoader : IAssetLoader
+	{
+		[DllImport("kernel32.dll")]
+		private static extern IntPtr LoadLibrary(string path);
+
+		private readonly DirectoryInfo _root;
+		private readonly Dictionary<Mod, ModInfo> _dirs;
+
+		// I would use the mod GUID over a ticket-system, but the mod GUID could contain invalid characters for the filesystem.
+		private int _ticket;
+
+		public NativeAssemblyAssetLoader()
+		{
+			// 0 B temp file on disk used to reserve handle
+			var rootPath = Path.GetTempFileName();
+
+			_dirs = new Dictionary<Mod, ModInfo>();
+			_root = new DirectoryInfo(rootPath + ".d");
+
+			_root.Create();
+		}
+
+		public void LoadAsset(IServiceKernel kernel, Mod mod, string path)
+		{
+			var raw = mod.Resources.Get<byte[]>(path).Expect("Failed to find native assembly at: " + path);
+
+			var info = _dirs.GetOrInsertWith(mod, () => new ModInfo(_root, ref _ticket));
+			info.LoadAssembly(raw, Path.GetFileName(path));
+		}
+
+		private class ModInfo
+		{
+			public readonly DirectoryInfo Assemblies;
+
+			public int Ticket;
+
+			public ModInfo(DirectoryInfo root, ref int ticket)
+			{
+				Assemblies = root.CreateSubdirectory(ticket++.ToString());
+			}
+
+			public void LoadAssembly(byte[] raw, string name)
+			{
+				// Path to DLL on disk
+				var dest = Path.Combine(Assemblies.FullName, Ticket++ + "-" + name);
+
+				// Write packed DLL to disk DLL
+				File.WriteAllBytes(dest, raw);
+
+				// Load disk DLL
+				if (LoadLibrary(dest) == IntPtr.Zero)
+				{
+					var err = Marshal.GetLastWin32Error();
+					throw new Win32Exception(err, "Failed to load native assembly at " + dest);
+				}
+			}
+		}
+	}
+}

--- a/Deli.Core/src/AssetLoaders/NativeAssembly.cs
+++ b/Deli.Core/src/AssetLoaders/NativeAssembly.cs
@@ -10,7 +10,7 @@ namespace Deli.Core
 	[QuickNamedBind("assembly.native")]
 	public class NativeAssemblyAssetLoader : IAssetLoader
 	{
-		[DllImport("kernel32.dll")]
+		[DllImport("kernel32.dll", SetLastError = true)]
 		private static extern IntPtr LoadLibrary(string path);
 
 		private readonly DirectoryInfo _root;

--- a/Deli/src/Entities/Mods/Mod.cs
+++ b/Deli/src/Entities/Mods/Mod.cs
@@ -8,7 +8,7 @@ using Valve.Newtonsoft.Json;
 
 namespace Deli
 {
-	public readonly struct Mod
+	public class Mod
 	{
 		/// <summary>
 		///		Information about the mod


### PR DESCRIPTION
- Adds the `assembly.native` asset loader that can load native (`DllImport`able) assemblies, e.g. Discord GameSDK
- Changes `Mod` from `readonly struct` to `class` (requires code referencing `Mod` to be rebuilt) because of internal dictionary usage. Making this a struct in the first place was a mistake on my part and should be fixed early.